### PR TITLE
optimize memory usage (save device memory)

### DIFF
--- a/host/inc/performdocking.h.Cuda
+++ b/host/inc/performdocking.h.Cuda
@@ -68,7 +68,7 @@ void copy_map_to_gpu(	GpuTempData& tData,
 			int size_of_one_map);
 
 void setup_gpu_for_docking(GpuData& cData, 
-                           GpuTempData& tData);
+                           GpuTempData& tData, Dockpars& mypars);
 void finish_gpu_from_docking(GpuData& cData, 
                              GpuTempData& tData);
 int docking_with_gpu(const Gridinfo* 		mygrid,

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -126,12 +126,7 @@ int main(int argc, char* argv[])
 			break;
 		}
 	}
-#ifdef USE_OMPT
-        cData.devnum = 0;
-	setup_gpu_for_docking(cData);
-#else
-	setup_gpu_for_docking(cData, tData);
-#endif
+
 
 #endif
 
@@ -157,6 +152,14 @@ int main(int argc, char* argv[])
 				// Copy preloaded maps to GPU
 				setup_time=seconds_since(setup_timer);
 			}
+#ifndef USE_KOKKOS
+#ifdef USE_OMPT
+        cData.devnum = 0;
+	setup_gpu_for_docking(cData);
+#else
+	setup_gpu_for_docking(cData, tData, mypars);
+#endif
+#endif
 
 			// Starting Docking
 	        unsigned int repeats = mypars.num_of_docks;

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -144,7 +144,7 @@ void copy_map_to_gpu(	GpuTempData& tData,
 	}
 }
 
-void setup_gpu_for_docking(GpuData& cData, GpuTempData& tData)
+void setup_gpu_for_docking(GpuData& cData, GpuTempData& tData, Dockpars& mypars)
 {
     auto const t0 = std::chrono::steady_clock::now();
 
@@ -234,7 +234,7 @@ void setup_gpu_for_docking(GpuData& cData, GpuTempData& tData)
         status = cudaMalloc((void**)&(tData.pMem_fgrids), cData.preload_gridsize * (sizeof(float)) * (ATYPE_NUM+2));
 	RTERROR(status, "pMem_fgrids: failed to allocate GPU memory.\n");
     }*/
-    size_t size_populations = MAX_NUM_OF_RUNS * MAX_POPSIZE * GENOTYPE_LENGTH_IN_GLOBMEM*sizeof(float);
+    size_t size_populations = mypars.num_of_runs * mypars.pop_size * GENOTYPE_LENGTH_IN_GLOBMEM*sizeof(float);
     status = cudaMalloc((void**)&(tData.pMem_conformations1), size_populations);
     RTERROR(status, "pMem_conformations1: failed to allocate GPU memory.\n");   
     status = cudaMalloc((void**)&(tData.pMem_conformations2), size_populations);


### PR DESCRIPTION
Hi there, I am developing a tool for monitoring and saving GPU device memory usage. I noticed the `tData.pMem_conformations2` and `tData.pMem_conformations2` account for a large percentage of memory usage. We can use the actual input value to make their allocation, instead of the input boundary. So I passed the `mypars` variable to the `setup_gpu_for_docking` function to pass the input variable `num_of_runs ` and `mypars`. It saved over half of memory usage under default input. Does it make any sense? Can you merge my update? Any response would be appreciated.